### PR TITLE
ci: fix gh pages build title warning

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,5 +1,5 @@
 name: A curated list of awesome Livepeer resources.
-title: null
+title: A curated list of awesome Livepeer resources.
 markdown: GFM
 google_analytics: 
 # NOTE: Remove items below when https://github.com/pages-themes/primer/pull/85 is merged.


### PR DESCRIPTION
This pull request fixes a warning that was thrown stating that site title was not set.
