### PR TITLE
docs: prevent title from showing on gh-page

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,5 +1,5 @@
 name: A curated list of awesome Livepeer resources.
-title: A curated list of awesome Livepeer resources.
+title: null
 markdown: GFM
 google_analytics: 
 # NOTE: Remove items below when https://github.com/pages-themes/primer/pull/85 is merged.


### PR DESCRIPTION
This pull request removes the title property again since otherwise it is shown on the gh pages page.
