### PR TITLE
feat: add new streaming platforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,8 @@ A community curated list of projects, tutorials, demos, and resources within the
 - [Tribe Social](https://tribesocial.io/)
 - [Waves](https://wav3s.app/)
 - [Xeenon](https://xeenon.xyz/)
+- [retake.tv](https://retake.tv/)
+- [stream.place](https://stream.place/)
 
 ### AI-Powered Apps
 


### PR DESCRIPTION
This pull request adds two new streaming platforms to the list which use livepeer under
the hood (i.e. stream.place and retake.tv).
