### PR TITLE
docs: add LiveWatcher to Delegator Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ A community curated list of projects, tutorials, demos, and resources within the
 ### Delegator Tools
 
 - [Livepeer Income Reports](https://github.com/rickstaa/livepeer-income-reports) - A collection of Python scripts for Livepeer delegators and orchestrators to calculate earnings and rewards and generate tax reports.
+- [LiveWatcher](https://livewatcher.xyz) - A delegator and orchestrator monitoring PWA that tracks stake, pending fees, and earnings, and sends alerts for reward-cut/fee-cut changes, missed reward calls, and governance proposals via Telegram, Discord, or email.
 
 ### Orchestrator Pools
 


### PR DESCRIPTION
## What

Adds [LiveWatcher](https://livewatcher.xyz) to the **Network Tools → Delegator Tools** section.

## Why

LiveWatcher is a free, open delegator and orchestrator monitoring PWA for the Livepeer network (Arbitrum One). It helps delegators keep an eye on their position without checking the explorer manually:

- Tracks stake, pending stake/fees, and per-round/7d/30d earnings for any delegator or orchestrator wallet (address or ENS).
- Sends alerts for reward-cut / fee-cut changes, missed reward calls, round claim reports, and governance proposals.
- Notification channels: Telegram, Discord, and email; weekly/monthly digests.
- No accounts or sign-up required; CSV export for record keeping.

Follows the contribution guidelines: added to the bottom of the existing Delegator Tools section in the required `- [Item Name](link) - Description.` format.

🤖 Generated with [Claude Code](https://claude.com/claude-code)